### PR TITLE
feat: 🎸 Added template parser

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -4,8 +4,7 @@
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "target": "es2020",
-    "module": "es2015",
-    "baseUrl": "."
+    "module": "es2015"
   },
   "exclude": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "lint:fix": "npm run lint -- --fix",
     "dev": "nodemon ./src/dev.js",
     "build": "babel src --out-dir dist",
-    "commit": "git-cz",
-    "preversion": "npm run test; npm run build;"
+    "commit": "git-cz"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,11 @@
 import { webpackParser } from './parser/webpackParser';
 import { argsParser } from './parser/argsParser';
+import { templateParser } from './parser/templateParser';
 import { persist, success, error, info } from './lib/utils';
 import { argv } from './lib/yargs';
 
 async function main() {
-  const parsers = [argsParser, webpackParser];
+  const parsers = [argsParser, templateParser, webpackParser];
   info('Initializing jsconfig.json parser...');
 
   try {

--- a/src/parser/__tests__/__snapshots__/templateParser.test.js.snap
+++ b/src/parser/__tests__/__snapshots__/templateParser.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DependencyTemplateMap should match snapshot 1`] = `
+Object {
+  "nextjs": Array [
+    "next",
+  ],
+  "react": Array [
+    "react",
+    "react-dom",
+    "react-scripts",
+  ],
+}
+`;

--- a/src/parser/__tests__/templateParser.test.js
+++ b/src/parser/__tests__/templateParser.test.js
@@ -1,0 +1,82 @@
+import fs from 'fs';
+import {
+  templateParser,
+  extractTemplate,
+  DependencyTemplateMap
+} from '../templateParser';
+
+describe('DependencyTemplateMap', () => {
+  it('should match snapshot', () => {
+    expect(DependencyTemplateMap).toMatchSnapshot();
+  });
+});
+
+describe('extractTemplate()', () => {
+  it('should return null for package.json without dependencies', () => {
+    expect(extractTemplate({})).toBeNull();
+    expect(extractTemplate(null)).toBeNull();
+    expect(extractTemplate(undefined)).toBeNull();
+    expect(extractTemplate({ name: 'package-name' })).toBeNull();
+    expect(extractTemplate({ devDependencies: { react: '16.x' } })).toBeNull();
+  });
+
+  it.each([
+    ['nextjs', { next: '16.x' }],
+    ['nextjs', { next: '16.x', axios: '*', fetch: '^1.2.3' }],
+    ['react', { react: '16.x' }],
+    [
+      'react',
+      { '@ima/core': '17.x', 'react-dom': '17.x', 'react-scripts': '^1.2.3' }
+    ],
+    ['react', { react: '17.x', 'react-dom': '17.x', 'react-scripts': '^1.2.3' }]
+  ])(
+    'should return "%s" template for %j dependencies',
+    (template, dependencies) => {
+      expect(extractTemplate({ dependencies })).toBe(template);
+    }
+  );
+
+  it('should return null for unmatched dependencies', () => {
+    expect(
+      extractTemplate({
+        dependencies: {
+          '@ima/core': '17.x',
+          '@ima/plugin-atoms': '17.x'
+        }
+      })
+    ).toBeNull();
+
+    expect(
+      extractTemplate({
+        devDependencies: {
+          react: '17.x'
+        },
+        dependencies: {
+          axios: '*'
+        }
+      })
+    ).toBeNull();
+  });
+});
+
+describe('templateParser()', () => {
+  let baseConfig = {
+    params: {
+      cwd: './'
+    },
+    config: {
+      compilerOptions: {
+        baseUrl: './',
+        paths: {
+          '@library/*': ['./=>lib/core/index.es5/*']
+        }
+      }
+    }
+  };
+
+  it('should return input args if package.json does not exist', async () => {
+    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+
+    expect(await templateParser(baseConfig)).toStrictEqual(baseConfig);
+  });
+});

--- a/src/parser/templateParser.js
+++ b/src/parser/templateParser.js
@@ -1,0 +1,63 @@
+import path from 'path';
+import fs from 'fs';
+
+const DependencyTemplateMap = Object.freeze({
+  nextjs: ['next'],
+  react: ['react', 'react-dom', 'react-scripts']
+});
+
+/**
+ * Looks at package.json dependencies and tries to match corresponding
+ * template based on dependencies defined in DependencyTemplateMap.
+ *
+ * @param {object} pkgJson Parsed package.json.
+ * @return {string|null} Matched template name or null.
+ */
+function extractTemplate(pkgJson) {
+  const { dependencies } = pkgJson || {};
+
+  if (!dependencies) {
+    return null;
+  }
+
+  for (let dependency in dependencies) {
+    for (let template in DependencyTemplateMap) {
+      if (DependencyTemplateMap[template].includes(dependency)) {
+        return template;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Tries to figure out the best default template to choose based on the CWD
+ * package.json dependencies.
+ *
+ * @param {{ params, config }} args Object with params and config objects,
+ *        used to carry config and params across parsers.
+ * @return {Promise<{ params, config }>} Modified params and config objects.
+ */
+async function templateParser({ params, config }) {
+  const { cwd } = params;
+  const packageJsonPath = path.resolve(cwd, 'package.json');
+
+  if (!fs.existsSync(packageJsonPath)) {
+    return { params, config };
+  }
+
+  return {
+    params: {
+      ...params,
+      template: extractTemplate(require(packageJsonPath)) || params.template
+    },
+    config: {
+      ...config
+    }
+  };
+}
+
+templateParser.parserName = 'template parser';
+
+export { templateParser, extractTemplate, DependencyTemplateMap };


### PR DESCRIPTION
Template parser tries to detect which base template should be used for
jsconfig generation based on project dependencies (currently only nextjs
and react are supported)